### PR TITLE
fix: use codex exec for adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Toryo ships with first-class adapters for 5 tools + a generic adapter for anythi
 | `aider` | [Aider](https://aider.chat) | `aider --message` |
 | `gemini-cli` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --prompt` |
 | `ollama` | [Ollama](https://ollama.ai) | Direct HTTP API (no CLI needed) |
-| `codex` | [Codex CLI](https://github.com/openai/codex) | `codex --prompt` |
+| `codex` | [Codex CLI](https://github.com/openai/codex) | `codex exec` |
 | `custom` | Any CLI tool | Configurable command + args |
 
 Mix and match — use Claude Code for research, Ollama for local code generation, and Gemini for review:

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -130,16 +130,16 @@ gemini --model gemini-2.5-pro --prompt "your prompt here"
 
 ### Codex CLI (`codex`)
 
-Wraps the [Codex CLI](https://github.com/openai/codex) using `--prompt` mode.
+Wraps the [Codex CLI](https://github.com/openai/codex) using `exec` mode with stdin.
 
 **Prerequisites:** Install Codex CLI and configure your OpenAI API key.
 
 **How it runs:**
 
 ```bash
-codex --prompt "your prompt here"
+echo "your prompt here" | codex exec -
 # With model selection:
-codex --model o4-mini --prompt "your prompt here"
+echo "your prompt here" | codex exec --model o4-mini -
 ```
 
 **Config example:**

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -30,7 +30,7 @@ const ollama = new OllamaAdapter('http://localhost:11434');
 | `claude-code` | Claude Code | `claude --print` |
 | `aider` | Aider | `aider --message` |
 | `gemini-cli` | Gemini CLI | `gemini --prompt` |
-| `codex` | Codex CLI | `codex --prompt` |
+| `codex` | Codex CLI | `codex exec` |
 | `ollama` | Ollama | Direct HTTP API |
 | `custom` | Any CLI | Configurable command + args |
 

--- a/packages/adapters/src/__tests__/adapters.test.ts
+++ b/packages/adapters/src/__tests__/adapters.test.ts
@@ -92,14 +92,15 @@ describe('CodexAdapter', () => {
     expect(adapter.name).toBe('codex');
   });
 
-  it('builds command with --prompt', () => {
-    const { command, args } = adapter.buildCommand({
+  it('builds command with exec and stdin mode', () => {
+    const { command, args, useStdin } = adapter.buildCommand({
       agentId: 'test',
       prompt: 'test',
       timeout: 60,
     });
     expect(command).toBe('codex');
-    expect(args).toContain('--prompt');
+    expect(args).toEqual(['exec', '-']);
+    expect(useStdin).toBe(true);
   });
 });
 

--- a/packages/adapters/src/codex.ts
+++ b/packages/adapters/src/codex.ts
@@ -3,19 +3,21 @@ import type { AdapterSendOptions } from 'toryo-core';
 
 /**
  * Adapter for Codex CLI (codex).
- * Uses --prompt mode for non-interactive single-prompt execution.
+ * Uses `codex exec` with stdin for non-interactive single-prompt execution.
  */
 export class CodexAdapter extends CliAdapter {
   name = 'codex';
 
   buildCommand(options: AdapterSendOptions) {
-    const args = ['--prompt', '{{PROMPT}}'];
+    const args = ['exec'];
 
     if (options.model) {
-      args.unshift('--model', options.model);
+      args.push('--model', options.model);
     }
 
-    return { command: 'codex', args };
+    args.push('-');
+
+    return { command: 'codex', args, useStdin: true };
   }
 
   parseOutput(stdout: string): string {


### PR DESCRIPTION
Updates the Codex adapter to use `codex exec` for non-interactive runs, updates the related adapter test, and refreshes the Codex docs/examples.

Verification:
- npm test -w packages/adapters
- npm run build
- npm test