### PR TITLE
feat(adapters): add Cursor CLI adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Toryo are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Cursor CLI adapter (`cursor`)** — wraps the `agent -p --force` non-interactive mode for the Cursor coding CLI. Requires `CURSOR_API_KEY`. Closes #31.
+
 ## [0.3.0] — 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ toryo dashboard            # open web dashboard
 
 ## Adapters
 
-Toryo ships with first-class adapters for 5 tools + a generic adapter for anything else:
+Toryo ships with first-class adapters for 6 tools + a generic adapter for anything else:
 
 | Adapter | Tool | How it works |
 |---------|------|-------------|
@@ -143,6 +143,7 @@ Toryo ships with first-class adapters for 5 tools + a generic adapter for anythi
 | `gemini-cli` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --prompt` |
 | `ollama` | [Ollama](https://ollama.ai) | Direct HTTP API (no CLI needed) |
 | `codex` | [Codex CLI](https://github.com/openai/codex) | `codex exec` |
+| `cursor` | [Cursor CLI](https://cursor.com/docs/cli/overview) | `agent -p --force` (requires `CURSOR_API_KEY`) |
 | `custom` | Any CLI tool | Configurable command + args |
 
 Mix and match — use Claude Code for research, Ollama for local code generation, and Gemini for review:

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -155,6 +155,40 @@ echo "your prompt here" | codex exec --model o4-mini -
 
 **Availability check:** Runs `which codex`.
 
+### Cursor CLI (`cursor`)
+
+Wraps the [Cursor agent CLI](https://cursor.com/docs/cli/headless) using `-p` (print) mode with `--force` for non-interactive autonomous execution.
+
+**Prerequisites:** Install the Cursor CLI (`agent` binary) and set `CURSOR_API_KEY` in your environment.
+
+**How it runs:**
+
+```bash
+agent -p --force --output-format text "your prompt here"
+# With model selection:
+agent --model cursor-fast -p --force --output-format text "your prompt here"
+```
+
+**Config example:**
+
+```json
+{
+  "adapter": "cursor",
+  "model": "cursor-fast",
+  "strengths": ["code", "implementation", "refactoring"],
+  "timeout": 900
+}
+```
+
+**Flags used:**
+- `-p` / `--print` -- Non-interactive mode (single prompt, single response).
+- `--force` -- Allow direct file modifications without per-action approval. Required for orchestrator usage.
+- `--output-format text` -- Plain text output (Toryo also supports `json` and `stream-json` formats via custom adapter usage).
+
+**Authentication:** Set `CURSOR_API_KEY` in the environment. Toryo passes the parent process's environment through, so exporting the key in the shell that runs `toryo run` is sufficient.
+
+**Availability check:** Runs `which agent`.
+
 ### Ollama (`ollama`)
 
 Connects directly to [Ollama's](https://ollama.ai) HTTP API. Unlike the other adapters, this does not spawn a CLI process -- it makes HTTP requests to the Ollama server.
@@ -231,7 +265,7 @@ const claude = createAdapter('claude-code');
 const ollama = createAdapter('ollama', { baseUrl: 'http://gpu-server:11434' });
 ```
 
-Supported names: `claude-code`, `aider`, `gemini-cli`, `codex`, `ollama`.
+Supported names: `claude-code`, `aider`, `gemini-cli`, `codex`, `cursor`, `ollama`.
 
 ## Writing Your Own Adapter
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -31,6 +31,7 @@ const ollama = new OllamaAdapter('http://localhost:11434');
 | `aider` | Aider | `aider --message` |
 | `gemini-cli` | Gemini CLI | `gemini --prompt` |
 | `codex` | Codex CLI | `codex exec` |
+| `cursor` | Cursor CLI | `agent -p --force` |
 | `ollama` | Ollama | Direct HTTP API |
 | `custom` | Any CLI | Configurable command + args |
 

--- a/packages/adapters/src/__tests__/adapters.test.ts
+++ b/packages/adapters/src/__tests__/adapters.test.ts
@@ -4,6 +4,7 @@ import {
   AiderAdapter,
   GeminiCliAdapter,
   CodexAdapter,
+  CursorAdapter,
   OllamaAdapter,
   CustomAdapter,
   createAdapter,
@@ -104,6 +105,43 @@ describe('CodexAdapter', () => {
   });
 });
 
+describe('CursorAdapter', () => {
+  const adapter = new CursorAdapter();
+
+  it('has correct name', () => {
+    expect(adapter.name).toBe('cursor');
+  });
+
+  it('builds command with -p, --force, and {{PROMPT}}', () => {
+    const { command, args } = adapter.buildCommand({
+      agentId: 'test',
+      prompt: 'test',
+      timeout: 60,
+    });
+    expect(command).toBe('agent');
+    expect(args).toContain('-p');
+    expect(args).toContain('--force');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('text');
+    expect(args).toContain('{{PROMPT}}');
+  });
+
+  it('includes --model when model is specified', () => {
+    const { args } = adapter.buildCommand({
+      agentId: 'test',
+      prompt: 'test',
+      timeout: 60,
+      model: 'cursor-fast',
+    });
+    expect(args).toContain('--model');
+    expect(args).toContain('cursor-fast');
+  });
+
+  it('parseOutput trims whitespace', () => {
+    expect(adapter.parseOutput('  hello world  \n', '')).toBe('hello world');
+  });
+});
+
 describe('OllamaAdapter', () => {
   it('has correct name', () => {
     const adapter = new OllamaAdapter();
@@ -161,6 +199,11 @@ describe('createAdapter', () => {
   it('creates codex adapter', () => {
     const adapter = createAdapter('codex');
     expect(adapter.name).toBe('codex');
+  });
+
+  it('creates cursor adapter', () => {
+    const adapter = createAdapter('cursor');
+    expect(adapter.name).toBe('cursor');
   });
 
   it('creates ollama adapter', () => {

--- a/packages/adapters/src/cursor.ts
+++ b/packages/adapters/src/cursor.ts
@@ -1,0 +1,29 @@
+import { CliAdapter } from './base.js';
+import type { AdapterSendOptions } from 'toryo-core';
+
+/**
+ * Adapter for Cursor agent CLI.
+ * Uses --print (-p) mode with --force for non-interactive autonomous orchestration.
+ * Requires the CURSOR_API_KEY environment variable for authentication.
+ */
+export class CursorAdapter extends CliAdapter {
+  name = 'cursor';
+
+  buildCommand(options: AdapterSendOptions) {
+    const args = ['-p', '--force', '--output-format', 'text', '{{PROMPT}}'];
+
+    if (options.model) {
+      args.unshift('--model', options.model);
+    }
+
+    return { command: 'agent', args };
+  }
+
+  parseOutput(stdout: string): string {
+    return stdout.trim();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.commandExists('agent');
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,6 +1,7 @@
 export { CliAdapter } from './base.js';
 export { ClaudeCodeAdapter } from './claude-code.js';
 export { CodexAdapter } from './codex.js';
+export { CursorAdapter } from './cursor.js';
 export { AiderAdapter } from './aider.js';
 export { GeminiCliAdapter } from './gemini-cli.js';
 export { OllamaAdapter } from './ollama.js';
@@ -9,6 +10,7 @@ export { CustomAdapter } from './custom.js';
 import type { AgentAdapter } from 'toryo-core';
 import { ClaudeCodeAdapter } from './claude-code.js';
 import { CodexAdapter } from './codex.js';
+import { CursorAdapter } from './cursor.js';
 import { AiderAdapter } from './aider.js';
 import { GeminiCliAdapter } from './gemini-cli.js';
 import { OllamaAdapter } from './ollama.js';
@@ -20,6 +22,8 @@ export function createAdapter(name: string, options?: Record<string, unknown>): 
       return new ClaudeCodeAdapter();
     case 'codex':
       return new CodexAdapter();
+    case 'cursor':
+      return new CursorAdapter();
     case 'aider':
       return new AiderAdapter();
     case 'gemini-cli':

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -311,7 +311,7 @@ async function initCommand() {
   console.log('\n棟梁 Toryo — Initializing...\n');
 
   // Detect available tools
-  const tools = ['claude-code', 'aider', 'gemini-cli', 'codex', 'ollama'] as const;
+  const tools = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama'] as const;
   const available: string[] = [];
 
   for (const name of tools) {

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -59,7 +59,7 @@ describe('validateConfig', () => {
   });
 
   it('accepts all known adapters', () => {
-    for (const adapter of ['claude-code', 'aider', 'gemini-cli', 'codex', 'ollama', 'custom']) {
+    for (const adapter of ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama', 'custom']) {
       const result = validateConfig({
         agents: { a: { adapter, strengths: ['code'], timeout: 60 } },
         tasks: './specs/',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToryoConfig } from './types.js';
 
-const KNOWN_ADAPTERS = ['claude-code', 'aider', 'gemini-cli', 'codex', 'ollama', 'custom'];
+const KNOWN_ADAPTERS = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama', 'custom'];
 const KNOWN_PROVIDERS = ['ntfy', 'slack', 'discord', 'webhook', 'none'];
 
 const AgentProfileSchema = z.object({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,7 @@ export type AutonomyLevel = 'supervised' | 'guided' | 'autonomous';
 export interface AgentProfile {
   /** Optional identifier (agents are typically keyed by ID in the config record) */
   id?: string;
-  /** Which adapter to use (claude-code, aider, gemini-cli, ollama, codex, custom) */
+  /** Which adapter to use (claude-code, aider, gemini-cli, ollama, codex, cursor, custom) */
   adapter: string;
   /** Model name passed to the adapter */
   model?: string;


### PR DESCRIPTION
## Summary

Adds a `cursor` adapter that wraps the Cursor agent CLI in non-interactive print mode for orchestrator usage. Closes #31.

## Changes

- New `packages/adapters/src/cursor.ts` extending `CliAdapter`. Default invocation: `agent -p --force --output-format text {{PROMPT}}`. Optional `--model` when `options.model` is set.
- Registered in factory (`packages/adapters/src/index.ts`).
- Added to `KNOWN_ADAPTERS` (`packages/core/src/config.ts`) so `toryo.config.json` accepts `"adapter": "cursor"`.
- Added to CLI tool detection in `toryo init` (`packages/cli/src/index.ts`).
- Updated `AgentProfile.adapter` docstring in `packages/core/src/types.ts`.
- Updated docs: top-level README, `packages/adapters/README.md`, `docs/adapters.md` (full guide section).
- Added 5 new tests covering name, command shape, `--model` insertion, and `parseOutput` trim.
- CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `npm run build` succeeds across core/adapters/cli.
- [x] `npm test` passes (269 tests total: 243 core + 26 adapters).
- [x] New adapter registered in factory and accessible via `createAdapter('cursor')`.
- [x] Config validation accepts `"adapter": "cursor"`.

## Notes

- Initial implementation uses `{{PROMPT}}` arg-substitution matching the existing `aider`/`gemini-cli` pattern. Issue #30 will migrate all four to `useStdin: true` in a coordinated change.
- `--force` is on by default because orchestrator usage is by definition autonomous. Per-task opt-out can be added later via constructor options if needed.
- Authentication uses the parent process's `CURSOR_API_KEY` (Toryo passes env through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)