### PR TITLE
feat(adapters): add Cline CLI adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Toryo are documented here.
 
 ### Added
 - **Cursor CLI adapter (`cursor`)** — wraps the `agent -p --force` non-interactive mode for the Cursor coding CLI. Requires `CURSOR_API_KEY`. Closes #31.
+- **Cline CLI adapter (`cline`)** — wraps `cline --yolo` for non-interactive orchestrator usage. Authenticates via `cline auth`. Closes #32.
 
 ## [0.3.0] — 2026-04-17
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ toryo dashboard            # open web dashboard
 
 ## Adapters
 
-Toryo ships with first-class adapters for 6 tools + a generic adapter for anything else:
+Toryo ships with first-class adapters for 7 tools + a generic adapter for anything else:
 
 | Adapter | Tool | How it works |
 |---------|------|-------------|
@@ -144,6 +144,7 @@ Toryo ships with first-class adapters for 6 tools + a generic adapter for anythi
 | `ollama` | [Ollama](https://ollama.ai) | Direct HTTP API (no CLI needed) |
 | `codex` | [Codex CLI](https://github.com/openai/codex) | `codex exec` |
 | `cursor` | [Cursor CLI](https://cursor.com/docs/cli/overview) | `agent -p --force` (requires `CURSOR_API_KEY`) |
+| `cline` | [Cline CLI](https://cline.bot) | `cline --yolo` |
 | `custom` | Any CLI tool | Configurable command + args |
 
 Mix and match — use Claude Code for research, Ollama for local code generation, and Gemini for review:

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -189,6 +189,38 @@ agent --model cursor-fast -p --force --output-format text "your prompt here"
 
 **Availability check:** Runs `which agent`.
 
+### Cline CLI (`cline`)
+
+Wraps the [Cline CLI 2.0](https://cline.bot) using `--yolo` mode for auto-approval in non-interactive orchestrator usage.
+
+**Prerequisites:** Install Cline (`npm install -g cline`) and run `cline auth` to configure credentials.
+
+**How it runs:**
+
+```bash
+cline --yolo "your prompt here"
+# With model selection:
+cline --model claude-sonnet-4-6 --yolo "your prompt here"
+```
+
+**Config example:**
+
+```json
+{
+  "adapter": "cline",
+  "model": "claude-sonnet-4-6",
+  "strengths": ["code", "implementation"],
+  "timeout": 900
+}
+```
+
+**Flags used:**
+- `--yolo` (alias `-y`) -- Auto-approve all actions for non-interactive runs. Required for orchestrator usage.
+
+**Authentication:** Cline manages credentials through `cline auth` and stores them in its configuration directory. Toryo does not need to set environment variables.
+
+**Availability check:** Runs `which cline`.
+
 ### Ollama (`ollama`)
 
 Connects directly to [Ollama's](https://ollama.ai) HTTP API. Unlike the other adapters, this does not spawn a CLI process -- it makes HTTP requests to the Ollama server.
@@ -265,7 +297,7 @@ const claude = createAdapter('claude-code');
 const ollama = createAdapter('ollama', { baseUrl: 'http://gpu-server:11434' });
 ```
 
-Supported names: `claude-code`, `aider`, `gemini-cli`, `codex`, `cursor`, `ollama`.
+Supported names: `claude-code`, `aider`, `gemini-cli`, `codex`, `cursor`, `cline`, `ollama`.
 
 ## Writing Your Own Adapter
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -32,6 +32,7 @@ const ollama = new OllamaAdapter('http://localhost:11434');
 | `gemini-cli` | Gemini CLI | `gemini --prompt` |
 | `codex` | Codex CLI | `codex exec` |
 | `cursor` | Cursor CLI | `agent -p --force` |
+| `cline` | Cline CLI 2.0 | `cline --yolo` |
 | `ollama` | Ollama | Direct HTTP API |
 | `custom` | Any CLI | Configurable command + args |
 

--- a/packages/adapters/src/__tests__/adapters.test.ts
+++ b/packages/adapters/src/__tests__/adapters.test.ts
@@ -5,6 +5,7 @@ import {
   GeminiCliAdapter,
   CodexAdapter,
   CursorAdapter,
+  ClineAdapter,
   OllamaAdapter,
   CustomAdapter,
   createAdapter,
@@ -142,6 +143,40 @@ describe('CursorAdapter', () => {
   });
 });
 
+describe('ClineAdapter', () => {
+  const adapter = new ClineAdapter();
+
+  it('has correct name', () => {
+    expect(adapter.name).toBe('cline');
+  });
+
+  it('builds command with --yolo and {{PROMPT}}', () => {
+    const { command, args } = adapter.buildCommand({
+      agentId: 'test',
+      prompt: 'test',
+      timeout: 60,
+    });
+    expect(command).toBe('cline');
+    expect(args).toContain('--yolo');
+    expect(args).toContain('{{PROMPT}}');
+  });
+
+  it('includes --model when model is specified', () => {
+    const { args } = adapter.buildCommand({
+      agentId: 'test',
+      prompt: 'test',
+      timeout: 60,
+      model: 'sonnet-4-6',
+    });
+    expect(args).toContain('--model');
+    expect(args).toContain('sonnet-4-6');
+  });
+
+  it('parseOutput trims whitespace', () => {
+    expect(adapter.parseOutput('  hello world  \n', '')).toBe('hello world');
+  });
+});
+
 describe('OllamaAdapter', () => {
   it('has correct name', () => {
     const adapter = new OllamaAdapter();
@@ -204,6 +239,11 @@ describe('createAdapter', () => {
   it('creates cursor adapter', () => {
     const adapter = createAdapter('cursor');
     expect(adapter.name).toBe('cursor');
+  });
+
+  it('creates cline adapter', () => {
+    const adapter = createAdapter('cline');
+    expect(adapter.name).toBe('cline');
   });
 
   it('creates ollama adapter', () => {

--- a/packages/adapters/src/cline.ts
+++ b/packages/adapters/src/cline.ts
@@ -1,0 +1,28 @@
+import { CliAdapter } from './base.js';
+import type { AdapterSendOptions } from 'toryo-core';
+
+/**
+ * Adapter for Cline CLI 2.0 (cline).
+ * Uses --yolo for auto-approval in non-interactive orchestrator usage.
+ */
+export class ClineAdapter extends CliAdapter {
+  name = 'cline';
+
+  buildCommand(options: AdapterSendOptions) {
+    const args = ['--yolo', '{{PROMPT}}'];
+
+    if (options.model) {
+      args.unshift('--model', options.model);
+    }
+
+    return { command: 'cline', args };
+  }
+
+  parseOutput(stdout: string): string {
+    return stdout.trim();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.commandExists('cline');
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -2,6 +2,7 @@ export { CliAdapter } from './base.js';
 export { ClaudeCodeAdapter } from './claude-code.js';
 export { CodexAdapter } from './codex.js';
 export { CursorAdapter } from './cursor.js';
+export { ClineAdapter } from './cline.js';
 export { AiderAdapter } from './aider.js';
 export { GeminiCliAdapter } from './gemini-cli.js';
 export { OllamaAdapter } from './ollama.js';
@@ -11,6 +12,7 @@ import type { AgentAdapter } from 'toryo-core';
 import { ClaudeCodeAdapter } from './claude-code.js';
 import { CodexAdapter } from './codex.js';
 import { CursorAdapter } from './cursor.js';
+import { ClineAdapter } from './cline.js';
 import { AiderAdapter } from './aider.js';
 import { GeminiCliAdapter } from './gemini-cli.js';
 import { OllamaAdapter } from './ollama.js';
@@ -24,6 +26,8 @@ export function createAdapter(name: string, options?: Record<string, unknown>): 
       return new CodexAdapter();
     case 'cursor':
       return new CursorAdapter();
+    case 'cline':
+      return new ClineAdapter();
     case 'aider':
       return new AiderAdapter();
     case 'gemini-cli':

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -311,7 +311,7 @@ async function initCommand() {
   console.log('\n棟梁 Toryo — Initializing...\n');
 
   // Detect available tools
-  const tools = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama'] as const;
+  const tools = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'cline', 'ollama'] as const;
   const available: string[] = [];
 
   for (const name of tools) {

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -59,7 +59,7 @@ describe('validateConfig', () => {
   });
 
   it('accepts all known adapters', () => {
-    for (const adapter of ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama', 'custom']) {
+    for (const adapter of ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'cline', 'ollama', 'custom']) {
       const result = validateConfig({
         agents: { a: { adapter, strengths: ['code'], timeout: 60 } },
         tasks: './specs/',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToryoConfig } from './types.js';
 
-const KNOWN_ADAPTERS = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'ollama', 'custom'];
+const KNOWN_ADAPTERS = ['claude-code', 'aider', 'gemini-cli', 'codex', 'cursor', 'cline', 'ollama', 'custom'];
 const KNOWN_PROVIDERS = ['ntfy', 'slack', 'discord', 'webhook', 'none'];
 
 const AgentProfileSchema = z.object({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,7 @@ export type AutonomyLevel = 'supervised' | 'guided' | 'autonomous';
 export interface AgentProfile {
   /** Optional identifier (agents are typically keyed by ID in the config record) */
   id?: string;
-  /** Which adapter to use (claude-code, aider, gemini-cli, ollama, codex, cursor, custom) */
+  /** Which adapter to use (claude-code, aider, gemini-cli, ollama, codex, cursor, cline, custom) */
   adapter: string;
   /** Model name passed to the adapter */
   model?: string;


### PR DESCRIPTION
## Summary

Adds a `cline` adapter that wraps the [Cline CLI 2.0](https://cline.bot) in `--yolo` mode for non-interactive orchestrator usage. Closes #32.

## Changes

- New `packages/adapters/src/cline.ts` extending `CliAdapter`. Default invocation: `cline --yolo {{PROMPT}}`. Optional `--model` when `options.model` is set.
- Registered in factory (`packages/adapters/src/index.ts`).
- Added to `KNOWN_ADAPTERS` (`packages/core/src/config.ts`).
- Added to CLI tool detection in `toryo init`.
- Updated `AgentProfile.adapter` docstring.
- Updated docs: top-level README, `packages/adapters/README.md`, `docs/adapters.md` (full guide section).
- Added 5 tests covering name, command shape, `--model` insertion, and `parseOutput` trim.
- CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `npm run build` succeeds.
- [x] `npm test` passes (274 tests total: 243 core + 31 adapters).
- [x] Adapter accessible via `createAdapter('cline')`.
- [x] Config validation accepts `"adapter": "cline"`.

## Notes

- Authentication via `cline auth` (Cline manages its own credential store). No environment variable required.
- Initial implementation uses `{{PROMPT}}` arg-substitution, matching aider/gemini-cli/cursor. Issue #30 will migrate all four to `useStdin: true` later.
- Cline does support stdin context (`cat file.md | cline "summarize"`), but our orchestrator pattern is "send the task as the prompt," so positional arg is correct here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)