### PR TITLE
feat(adapters): claude-code 2026 flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Toryo are documented here.
 ### Added
 - **Cursor CLI adapter (`cursor`)** — wraps the `agent -p --force` non-interactive mode for the Cursor coding CLI. Requires `CURSOR_API_KEY`. Closes #31.
 - **Cline CLI adapter (`cline`)** — wraps `cline --yolo` for non-interactive orchestrator usage. Authenticates via `cline auth`. Closes #32.
+- **`ClaudeCodeAdapter` constructor options** — opt-in support for 2026-era flags: `bare`, `maxBudgetUsd`, `maxTurns`, `excludeDynamicSystemPromptSections`, `jsonSchema`, `agents`, and `sessionName`. Defaults preserve back-compat behavior. `createAdapter('claude-code', options)` passes the same options through. Closes #33.
 
 ## [0.3.0] — 2026-04-17
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -43,16 +43,16 @@ Most adapters extend the `CliAdapter` base class, which handles process executio
 
 ### Claude Code (`claude-code`)
 
-Wraps the [Claude Code CLI](https://claude.ai/code) using `--print` mode for non-interactive single-prompt execution.
+Wraps the [Claude Code CLI](https://claude.ai/code) using `--print` mode (with stdin) for non-interactive single-prompt execution.
 
 **Prerequisites:** Install Claude Code CLI and authenticate.
 
 **How it runs:**
 
 ```bash
-claude --print "your prompt here"
+claude --print -                   # prompt piped via stdin
 # With model selection:
-claude --model claude-sonnet-4-6 --print "your prompt here"
+claude --model claude-sonnet-4-6 --print -
 ```
 
 **Config example:**
@@ -67,6 +67,30 @@ claude --model claude-sonnet-4-6 --print "your prompt here"
 ```
 
 **Model selection:** Pass any model name supported by the Claude CLI (e.g., `claude-sonnet-4-6`, `claude-opus-4`). If `model` is omitted, the CLI uses its default model.
+
+**Adapter options (programmatic):** The `ClaudeCodeAdapter` constructor accepts a `ClaudeCodeAdapterOptions` object that maps to 2026-era CLI flags. Defaults preserve current behavior. Available fields:
+
+| Option | CLI flag | Effect |
+|--------|----------|--------|
+| `bare` | `--bare` | Skip auto-discovery of hooks, skills, plugins, MCP servers, and CLAUDE.md. Material latency win for orchestration. |
+| `maxBudgetUsd` | `--max-budget-usd N` | Cap dollar spend per task. |
+| `maxTurns` | `--max-turns N` | Cap turns per task. |
+| `excludeDynamicSystemPromptSections` | `--exclude-dynamic-system-prompt-sections` | Improve prompt-cache reuse across distributed workers. |
+| `jsonSchema` | `--json-schema <value>` | Validate output against a JSON schema (object or pre-stringified). |
+| `agents` | `--agents <json>` | Inline subagent definitions. |
+| `sessionName` | `-r <name>` | Resume a session by name. |
+
+```ts
+import { ClaudeCodeAdapter, createAdapter } from 'toryo-adapters';
+
+// Direct construction
+const fast = new ClaudeCodeAdapter({ bare: true, maxBudgetUsd: 2, maxTurns: 8 });
+
+// Or via the factory (options object passed through)
+const adapter = createAdapter('claude-code', { bare: true, maxBudgetUsd: 5 });
+```
+
+When using `toryo.config.json`, these options are not yet routable per-agent. Either construct the adapter programmatically or use `custom` until per-agent adapter options land.
 
 **Availability check:** Runs `which claude` to verify the CLI is installed.
 

--- a/packages/adapters/src/__tests__/adapters.test.ts
+++ b/packages/adapters/src/__tests__/adapters.test.ts
@@ -45,6 +45,80 @@ describe('ClaudeCodeAdapter', () => {
   it('parseOutput trims whitespace', () => {
     expect(adapter.parseOutput('  hello world  \n', '')).toBe('hello world');
   });
+
+  it('passes --bare when bare option is set', () => {
+    const a = new ClaudeCodeAdapter({ bare: true });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--bare');
+  });
+
+  it('passes --max-budget-usd N when option is set', () => {
+    const a = new ClaudeCodeAdapter({ maxBudgetUsd: 5 });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--max-budget-usd');
+    expect(args).toContain('5');
+  });
+
+  it('passes --max-turns N when option is set', () => {
+    const a = new ClaudeCodeAdapter({ maxTurns: 8 });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--max-turns');
+    expect(args).toContain('8');
+  });
+
+  it('passes --exclude-dynamic-system-prompt-sections when set', () => {
+    const a = new ClaudeCodeAdapter({ excludeDynamicSystemPromptSections: true });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--exclude-dynamic-system-prompt-sections');
+  });
+
+  it('serializes object jsonSchema to --json-schema', () => {
+    const a = new ClaudeCodeAdapter({ jsonSchema: { type: 'object' } });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--json-schema');
+    expect(args).toContain(JSON.stringify({ type: 'object' }));
+  });
+
+  it('passes string jsonSchema verbatim', () => {
+    const a = new ClaudeCodeAdapter({ jsonSchema: '{"x":1}' });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--json-schema');
+    expect(args).toContain('{"x":1}');
+  });
+
+  it('serializes agents object to --agents JSON', () => {
+    const a = new ClaudeCodeAdapter({ agents: { reviewer: { tools: ['read'] } } });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--agents');
+    expect(args).toContain(JSON.stringify({ reviewer: { tools: ['read'] } }));
+  });
+
+  it('passes -r <name> when sessionName is set', () => {
+    const a = new ClaudeCodeAdapter({ sessionName: 'auth-refactor' });
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('-r');
+    expect(args).toContain('auth-refactor');
+  });
+
+  it('default options match pre-2026-04 args (back-compat)', () => {
+    const a = new ClaudeCodeAdapter();
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).not.toContain('--bare');
+    expect(args).not.toContain('--max-budget-usd');
+    expect(args).not.toContain('--max-turns');
+    expect(args).not.toContain('--exclude-dynamic-system-prompt-sections');
+    expect(args).not.toContain('--json-schema');
+    expect(args).not.toContain('--agents');
+    expect(args).not.toContain('-r');
+  });
+
+  it('createAdapter passes options through to ClaudeCodeAdapter', () => {
+    const a = createAdapter('claude-code', { bare: true, maxBudgetUsd: 2 }) as ClaudeCodeAdapter;
+    const { args } = a.buildCommand({ agentId: 'test', prompt: 't', timeout: 60 });
+    expect(args).toContain('--bare');
+    expect(args).toContain('--max-budget-usd');
+    expect(args).toContain('2');
+  });
 });
 
 describe('AiderAdapter', () => {

--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -2,19 +2,89 @@ import { CliAdapter } from './base.js';
 import type { AdapterSendOptions } from 'toryo-core';
 
 /**
+ * Optional constructor configuration for ClaudeCodeAdapter.
+ * All fields are opt-in. Defaults preserve pre-2026-04 behavior.
+ */
+export interface ClaudeCodeAdapterOptions {
+  /**
+   * Skip auto-discovery of hooks, skills, plugins, MCP servers, and CLAUDE.md files.
+   * Material latency win when spawning many short-lived agents in orchestration.
+   */
+  bare?: boolean;
+  /**
+   * Cap dollar spend per task in print mode. Passed as `--max-budget-usd N`.
+   */
+  maxBudgetUsd?: number;
+  /**
+   * Cap turns per task in print mode. Passed as `--max-turns N`.
+   */
+  maxTurns?: number;
+  /**
+   * Exclude dynamic system prompt sections to improve prompt-cache reuse
+   * across distributed workers running the same agent.
+   */
+  excludeDynamicSystemPromptSections?: boolean;
+  /**
+   * JSON schema for output validation in print mode. Pass either an object
+   * (will be serialized) or a JSON string. Sent as `--json-schema <value>`.
+   */
+  jsonSchema?: string | object;
+  /**
+   * Inline subagent definitions. Will be JSON-serialized and passed as `--agents`.
+   */
+  agents?: object;
+  /**
+   * Resume an existing session by name. Passed as `-r <name>`.
+   */
+  sessionName?: string;
+}
+
+/**
  * Adapter for Claude Code CLI (claude).
  * Uses --print mode with stdin for non-interactive single-prompt execution.
  * Stdin avoids OS argument length limits on large prompts.
+ *
+ * Pass an options object to opt into 2026-era flags such as --bare,
+ * --max-budget-usd, --max-turns, --json-schema, etc.
  */
 export class ClaudeCodeAdapter extends CliAdapter {
   name = 'claude-code';
 
-  buildCommand(options: AdapterSendOptions) {
-    const args = ['--print', '-'];
+  constructor(private adapterOptions: ClaudeCodeAdapterOptions = {}) {
+    super();
+  }
 
-    if (options.model) {
-      args.unshift('--model', options.model);
+  buildCommand(options: AdapterSendOptions) {
+    const args: string[] = [];
+
+    if (this.adapterOptions.sessionName) {
+      args.push('-r', this.adapterOptions.sessionName);
     }
+    if (this.adapterOptions.bare) {
+      args.push('--bare');
+    }
+    if (this.adapterOptions.excludeDynamicSystemPromptSections) {
+      args.push('--exclude-dynamic-system-prompt-sections');
+    }
+    if (this.adapterOptions.maxBudgetUsd !== undefined) {
+      args.push('--max-budget-usd', String(this.adapterOptions.maxBudgetUsd));
+    }
+    if (this.adapterOptions.maxTurns !== undefined) {
+      args.push('--max-turns', String(this.adapterOptions.maxTurns));
+    }
+    if (this.adapterOptions.jsonSchema !== undefined) {
+      const schema = typeof this.adapterOptions.jsonSchema === 'string'
+        ? this.adapterOptions.jsonSchema
+        : JSON.stringify(this.adapterOptions.jsonSchema);
+      args.push('--json-schema', schema);
+    }
+    if (this.adapterOptions.agents !== undefined) {
+      args.push('--agents', JSON.stringify(this.adapterOptions.agents));
+    }
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+    args.push('--print', '-');
 
     return { command: 'claude', args, useStdin: true };
   }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,5 +1,5 @@
 export { CliAdapter } from './base.js';
-export { ClaudeCodeAdapter } from './claude-code.js';
+export { ClaudeCodeAdapter, type ClaudeCodeAdapterOptions } from './claude-code.js';
 export { CodexAdapter } from './codex.js';
 export { CursorAdapter } from './cursor.js';
 export { ClineAdapter } from './cline.js';
@@ -9,7 +9,7 @@ export { OllamaAdapter } from './ollama.js';
 export { CustomAdapter } from './custom.js';
 
 import type { AgentAdapter } from 'toryo-core';
-import { ClaudeCodeAdapter } from './claude-code.js';
+import { ClaudeCodeAdapter, type ClaudeCodeAdapterOptions } from './claude-code.js';
 import { CodexAdapter } from './codex.js';
 import { CursorAdapter } from './cursor.js';
 import { ClineAdapter } from './cline.js';
@@ -21,7 +21,7 @@ import { OllamaAdapter } from './ollama.js';
 export function createAdapter(name: string, options?: Record<string, unknown>): AgentAdapter {
   switch (name) {
     case 'claude-code':
-      return new ClaudeCodeAdapter();
+      return new ClaudeCodeAdapter(options as ClaudeCodeAdapterOptions | undefined);
     case 'codex':
       return new CodexAdapter();
     case 'cursor':


### PR DESCRIPTION
## Summary

Updates the `claude-code` adapter to expose 2026-era CLI flags via a new optional `ClaudeCodeAdapterOptions` constructor argument. Closes #33.

## What changed

- `packages/adapters/src/claude-code.ts`: added `ClaudeCodeAdapterOptions` interface, opt-in constructor, and conditional flag emission in `buildCommand`.
- `packages/adapters/src/index.ts`: exported the type, factory passes options through.
- Tests: 10 new cases covering each option, default back-compat, and factory pass-through.
- `docs/adapters.md`: full options table + programmatic example for the Claude Code section.
- CHANGELOG entry under `[Unreleased]`.

## Flags exposed

| Option | CLI flag | Why it matters |
|--------|----------|----------------|
| \`bare\` | \`--bare\` | Skip auto-discovery (hooks/skills/plugins/MCP/CLAUDE.md). Material latency win for orchestration. |
| \`maxBudgetUsd\` | \`--max-budget-usd N\` | Cap dollar spend per task. |
| \`maxTurns\` | \`--max-turns N\` | Cap turns per task. |
| \`excludeDynamicSystemPromptSections\` | \`--exclude-dynamic-system-prompt-sections\` | Better prompt-cache reuse across distributed workers. |
| \`jsonSchema\` | \`--json-schema <value>\` | Validated typed output. Object or pre-stringified. |
| \`agents\` | \`--agents <json>\` | Inline subagent definitions. |
| \`sessionName\` | \`-r <name>\` | Resume by session name. |

## Backwards compatibility

\`new ClaudeCodeAdapter()\` with no args produces identical args to the previous implementation. Verified by the new \`default options match pre-2026-04 args (back-compat)\` test.

## Test plan

- [x] \`npm run build\` succeeds.
- [x] \`npm test\` passes (284 tests total: 243 core + 41 adapters).
- [x] Each option produces the expected flag.
- [x] Object jsonSchema serialized; string jsonSchema passed verbatim.
- [x] Factory passes options through: \`createAdapter('claude-code', { bare: true })\`.

## Out of scope

- AgentBus → \`--agents\` automatic translation. Separate issue.
- OTEL TRACEPARENT/TRACESTATE propagation. Separate issue.
- Per-agent adapter options in \`toryo.config.json\` (currently options are programmatic only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)