### PR TITLE
fix(core): parse acceptance criteria from body when no frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Toryo are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`parseSpec` no-frontmatter path now parses acceptance criteria from the markdown body.** Previously, specs without a YAML frontmatter block always returned `acceptanceCriteria: []`, silently ignoring any `## Acceptance Criteria` / `## Criteria` / `### Done When` section in the body. The fix calls `parseAcceptanceCriteria(content)` in the no-frontmatter branch, matching the behaviour of the frontmatter path. A regression test covering all three bullet styles and checkbox stripping is added.
+
 ### Added
 - **Cursor CLI adapter (`cursor`)** — wraps the `agent -p --force` non-interactive mode for the Cursor coding CLI. Requires `CURSOR_API_KEY`. Closes #31.
 - **Cline CLI adapter (`cline`)** — wraps `cline --yolo` for non-interactive orchestrator usage. Authenticates via `cline auth`. Closes #32.

--- a/packages/core/src/__tests__/specs.test.ts
+++ b/packages/core/src/__tests__/specs.test.ts
@@ -15,6 +15,18 @@ describe('parseSpec', () => {
     expect(spec!.phases.length).toBe(4);
   });
 
+  it('parses acceptance criteria from body when no frontmatter', () => {
+    const content = `This is a task description.
+
+## Acceptance Criteria
+- Item one
+- [ ] Item two
+* Item three`;
+
+    const spec = parseSpec(content, 'my-task');
+    expect(spec!.acceptanceCriteria).toEqual(['Item one', 'Item two', 'Item three']);
+  });
+
   it('generates default phases with auto agent', () => {
     const spec = parseSpec('desc', 'task-1');
     expect(spec!.phases).toEqual([

--- a/packages/core/src/specs.ts
+++ b/packages/core/src/specs.ts
@@ -48,7 +48,7 @@ export function parseSpec(content: string, defaultId: string): TaskSpec | null {
       id: defaultId,
       name: defaultId.replace(/-/g, ' '),
       description: content.trim(),
-      acceptanceCriteria: [],
+      acceptanceCriteria: parseAcceptanceCriteria(content),
       phases: defaultPhases(),
     };
   }


### PR DESCRIPTION
## Summary

- `parseSpec` was hardcoding `acceptanceCriteria: []` in the no-frontmatter branch, silently discarding any `## Acceptance Criteria` / `## Criteria` / `### Done When` section in the markdown body.
- The frontmatter path correctly calls `parseAcceptanceCriteria(body)` — the no-frontmatter path simply never called it at all.
- One-line fix: pass `content` to `parseAcceptanceCriteria` instead of returning an empty array.

## Changes

- `packages/core/src/specs.ts` — call `parseAcceptanceCriteria(content)` in the no-frontmatter early-return path.
- `packages/core/src/__tests__/specs.test.ts` — regression test covering `-` bullets, `*` bullets, and `[ ]` checkbox stripping without a frontmatter block.
- `CHANGELOG.md` — entry under `[Unreleased] > Fixed`.

## Test plan

- [x] `npm run build` succeeds.
- [x] All 244 core tests pass (`vitest run` in `packages/core`).
- [x] All 41 adapter tests pass (`vitest run` in `packages/adapters`).
- [x] New test `parses acceptance criteria from body when no frontmatter` exercises the fixed path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)