### PR TITLE
chore(ci): add release-please for automated version bumps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "packages/core": "0.3.0",
+  "packages/adapters": "0.2.0",
+  "packages/cli": "0.2.0",
+  "packages/dashboard": "0.2.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "packages": {
+    "packages/core": {
+      "package-name": "toryo-core",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/adapters": {
+      "package-name": "toryo-adapters"
+    },
+    "packages/cli": {
+      "package-name": "@jweigel/toryo"
+    },
+    "packages/dashboard": {
+      "package-name": "@toryo/dashboard"
+    }
+  },
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "updatePeerDependencies": true
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "toryo",
+      "components": ["toryo-core", "toryo-adapters", "@jweigel/toryo", "@toryo/dashboard"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds [release-please](https://github.com/googleapis/release-please) automation so version bumps and CHANGELOG updates happen via auto-generated PRs whenever conventional-commit work lands on `main`.

**How it works:**
1. Push to `main` → release-please scans recent commits
2. If there are releasable commits (`feat:`, `fix:`, `chore!:`, etc.), it opens/updates a "release PR" with version bumps + CHANGELOG entries
3. Merging that PR creates a `v*` tag
4. Existing `release.yml` fires on the tag and publishes to npm

**Configuration:**
- `linked-versions` plugin keeps all four packages (`core`, `adapters`, `cli`, `dashboard`) on the same version
- `node-workspace` plugin updates inter-package dependencies automatically
- Manifest seeded with current versions: `core@0.3.0`, `adapters@0.2.0`, `cli@0.2.0`, `dashboard@0.2.0` — first run will sync them.

## Test plan

- [ ] Merge this PR
- [ ] Verify release-please workflow runs successfully on push to `main`
- [ ] Verify a release PR is opened (since PR #38 just merged a `fix:` commit)
- [ ] Merge the release PR → verify tag is created → verify `release.yml` publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)